### PR TITLE
add emoji keyword search (this time with test)

### DIFF
--- a/search.js
+++ b/search.js
@@ -17,7 +17,6 @@ module.exports = input => {
                     }
                 });
             }
-
         } else {
             searchResults.push(emojilib.lib[name].char);
         }

--- a/search.js
+++ b/search.js
@@ -10,7 +10,14 @@ module.exports = input => {
         if (typeof input !== 'undefined' && input !== '') {
             if (fuzzysearch(input, name)) {
                 searchResults.push(emojilib.lib[name].char);
+            } else {
+                emojilib.lib[name].keywords.forEach(keyword => {
+                    if (fuzzysearch(input, keyword)) {
+                        searchResults.push(emojilib.lib[name].char);
+                    }
+                });
             }
+
         } else {
             searchResults.push(emojilib.lib[name].char);
         }

--- a/search.test.js
+++ b/search.test.js
@@ -9,6 +9,13 @@ test('get rainbow emoji using search', () => {
     expect(searchResults[0]).toEqual('🌈');
 });
 
+test('get thumbsup emoji using search on keywords', () => {
+    const searchResults = search('thumbs');
+
+    expect(searchResults).toHaveLength(2);
+    expect(searchResults[0]).toEqual('👍');
+});
+
 test('get all emojis using search', () => {
     const searchResults = search('');
 


### PR DESCRIPTION
This patch makes smil search the keywords in the emojilib as well as the name of the emoji. Hint: search 'thumbs' in both versions